### PR TITLE
nanoauth has the X-NANOBOX-TOKEN header as the default

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -81,7 +81,6 @@ func StartApi() error {
 		return err
 	}
 	auth.Certificate = cert
-	auth.Header = "X-NANOBOX-TOKEN"
 
 	config.Log.Info("Api listening at https://%s:%s...", config.ApiHost, config.ApiPort)
 	return auth.ListenAndServeTLS(fmt.Sprintf("%s:%s", config.ApiHost, config.ApiPort), config.ApiToken, routes())


### PR DESCRIPTION
Seen [here](https://github.com/nanobox-io/golang-nanoauth/blob/master/nanoauth.go#L19)