### PR TITLE
Revert "nanoauth has the X-NANOBOX-TOKEN header as the default"

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -81,6 +81,7 @@ func StartApi() error {
 		return err
 	}
 	auth.Certificate = cert
+	auth.Header = "X-NANOBOX-TOKEN"
 
 	config.Log.Info("Api listening at https://%s:%s...", config.ApiHost, config.ApiPort)
 	return auth.ListenAndServeTLS(fmt.Sprintf("%s:%s", config.ApiHost, config.ApiPort), config.ApiToken, routes())


### PR DESCRIPTION
Reverts nanopack/portal#14
The `DefaultAuth` variable in `golang-nanoauth` does set the Header by default, but portal uses its own `Auth` type variable, which needs the header set.