### PR TITLE
Simplify DB `select ... case`

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -31,15 +31,11 @@ func Init() error {
 		return fmt.Errorf("Failed to parse db connection - %s", err)
 	}
 	switch u.Scheme {
+	case "postgres", "postgresql":
+		CentralStore = true
+		Backend = &PostgresDb{}
 	case "scribble":
-		CentralStore = false
-		Backend = &ScribbleDatabase{}
-	case "postgres":
-		CentralStore = true
-		Backend = &PostgresDb{}
-	case "postgresql":
-		CentralStore = true
-		Backend = &PostgresDb{}
+		fallthrough
 	default:
 		CentralStore = false
 		Backend = &ScribbleDatabase{}


### PR DESCRIPTION
- List multiple variations in spelling on the same line.
- Use `fallthrough` to allow `scribble` to count as the `default` case explicitly.